### PR TITLE
Removed bg

### DIFF
--- a/src/app/user/quiz/[quizId]/page.tsx
+++ b/src/app/user/quiz/[quizId]/page.tsx
@@ -439,7 +439,7 @@ export default function QuizPage() {
   if (!quizData) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <Card className="shadow-2xl bg-white/90 border border-blue-100 rounded-3xl p-10 max-w-md w-full">
+        <Card className="shadow-2xl border border-blue-100 rounded-3xl p-10 max-w-md w-full">
           <div className="flex flex-col items-center space-y-6">
             <div className="relative">
               <span className="absolute -top-2 -right-2 w-6 h-6 bg-yellow-300 rounded-full flex items-center justify-center animate-bounce z-10">


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the quiz page. The change removes the semi-transparent white background from the `Card` component that displays when quiz data is unavailable.

* Removed the `bg-white/90` class from the `Card` component in `src/app/user/quiz/[quizId]/page.tsx`, resulting in a less opaque background for the quiz data unavailable state. ([src/app/user/quiz/[quizId]/page.tsxL442-R442](diffhunk://#diff-658e4992c52a11549c6285a92c4e20b1ad4f005c03589dcb1d137a57bb916999L442-R442))