### PR TITLE
UPDATE: Error Messages

### DIFF
--- a/src/app/user/quiz/[quizId]/page.tsx
+++ b/src/app/user/quiz/[quizId]/page.tsx
@@ -453,7 +453,7 @@ export default function QuizPage() {
               <h2 className="text-2xl font-bold text-primary mb-2 drop-shadow">
                 Access Required
               </h2>
-              <p className="text-base text-gray-600 mb-4">
+              <p className="text-base text-primary mb-4">
                 You do not have access to this quiz.
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center mt-2">

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -20,9 +20,9 @@ const createUser = async (user: any) => {
     if (error instanceof AxiosError) {
       if (
         error.response?.data.message ===
-        "Error creating user: User already exists"
+        "Error creating user: Username or email already taken"
       ) {
-        throw new Error("User Already exist");
+        throw new Error("Username or email already taken");
       }
       throw new Error("Couldn't create, try again");
     }


### PR DESCRIPTION
This pull request introduces minor improvements to user-facing messages for clarity and consistency. The changes update the color of an access message and refine error handling to provide more precise feedback to users.

User interface improvements:

* Updated the access restriction message text color from `text-gray-600` to `text-primary` in the quiz access page for better visual consistency. ([src/app/user/quiz/[quizId]/page.tsxL456-R456](diffhunk://#diff-658e4992c52a11549c6285a92c4e20b1ad4f005c03589dcb1d137a57bb916999L456-R456))

Error handling improvements:

* Changed the error message in `createUser` to specify "Username or email already taken" instead of the less clear "User Already exist", improving feedback for duplicate user creation attempts.